### PR TITLE
Refactor wallpaper functionality

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use std::error::Error;
 use std::path::{Path, PathBuf};
 use std::thread;
 use std::time::Duration;
+use wallpapers::{Desktop, DesktopEnvt};
 
 mod wallpapers;
 
@@ -109,16 +110,18 @@ pub fn set_times(config: Config) {
     println!("Times - {:#?}", &times);
     println!("Paths - {:#?}", &walls);
 
+    let de = DesktopEnvt::new().expect("Desktop envt could not be determined");
+
     // set current wallpaper
     let current_index = get_current_wallpaper_idx(walls.len());
-    wallpapers::set_paper(&walls[current_index]).unwrap();
+    de.set_wallpaper(&walls[current_index]).unwrap();
 
     let mut scheduler = Scheduler::new();
     for (time, wall) in times.into_iter().zip(walls) {
         scheduler
             .every(1.day())
             .at(&time)
-            .run(move || wallpapers::set_paper(&wall).unwrap());
+            .run(move || de.set_wallpaper(&wall).unwrap());
     }
     loop {
         scheduler.run_pending();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,18 +110,18 @@ pub fn set_times(config: Config) {
     println!("Times - {:#?}", &times);
     println!("Paths - {:#?}", &walls);
 
-    let de = DesktopEnvt::new().expect("Desktop envt could not be determined");
+    let desktop_envt = DesktopEnvt::new().expect("Desktop envt could not be determined");
 
     // set current wallpaper
     let current_index = get_current_wallpaper_idx(walls.len());
-    de.set_wallpaper(&walls[current_index]).unwrap();
+    desktop_envt.set_wallpaper(&walls[current_index]).unwrap();
 
     let mut scheduler = Scheduler::new();
     for (time, wall) in times.into_iter().zip(walls) {
         scheduler
             .every(1.day())
             .at(&time)
-            .run(move || de.set_wallpaper(&wall).unwrap());
+            .run(move || desktop_envt.set_wallpaper(&wall).unwrap());
     }
     loop {
         scheduler.run_pending();

--- a/src/wallpapers.rs
+++ b/src/wallpapers.rs
@@ -1,204 +1,23 @@
 // THIS MODULE HANDLES THE SETTING AND GETTING
 // OF THE WALLPAPER
 use std::error::Error;
-use std::io::BufRead;
-use std::process::Command;
-
-/// Check if desktop is Gnome compliant
-#[cfg(target_os = "linux")]
-fn is_gnome_compliant(desktop: &str) -> bool {
-    desktop.contains("GNOME") || desktop == "Unity" || desktop == "Pantheon"
-}
-
-/// args - NONE
-/// return Result<String, Box<error>
-/// Purpose - Get's path of the current wallpaper
-#[cfg(target_os = "linux")]
-pub fn get_wallpaper() -> Result<String, Box<dyn Error>> {
-    let desktop = get_envt()?;
-
-    let output = match desktop.as_str() {
-        "GNOME" => Command::new("gsettings")
-            .args(&["get", "org.gnome.desktop.background", "picture-uri"])
-            .output()?,
-
-        "X-Cinnamon" => Command::new("dconf")
-            .arg("read")
-            .arg("/org/cinnamon/desktop/background/picture-uri")
-            .output()?,
-
-        "MATE" => Command::new("dconf")
-            .args(&["read", "/org/mate/desktop/background/picture-filename"])
-            .output()?,
-
-        "XFCE" => Command::new("xfconf-query")
-            .args(&[
-                "-c",
-                "xfce4-desktop",
-                "-p",
-                "/backdrop/screen0/monitor0/workspace0/last-image",
-            ])
-            .output()?,
-
-        "Deepin" => Command::new("dconf")
-            .args(&[
-                "read",
-                "/com/deepin/wrap/gnome/desktop/background/picture-uri",
-            ])
-            .output()?,
-
-        "KDE" => return Ok(kde_get()?),
-
-        // Panics since flowy does not support others yet
-        _ => panic!("Unsupported Desktop Environment"),
-    };
-
-    Ok(enquote::unquote(
-        String::from_utf8(output.stdout)?.trim().into(),
-    )?)
-}
+use std::path::PathBuf;
 
 #[cfg(target_os = "linux")]
-fn kde_get() -> Result<String, Box<dyn Error>> {
-    // Getting current directory and
-    // appending the kde wallpaper
-    // repo to the end of the path
-    let mut path = std::env::current_dir()?.display().to_string();
-    path.push_str("/plasma-org.kde.plasma.desktop-appletsrc");
-    // Opening the file into a buffer reader
-    let file = std::fs::File::open(path)?;
-    let reader = std::io::BufReader::new(file);
-    for line in reader.lines() {
-        let line = line?;
-        if line.starts_with("Image=") {
-            return Ok(line[6..].trim().into());
-        }
-    }
-
-    Err("KDE Image not found".into())
-}
+mod linux;
+#[cfg(target_os = "linux")]
+pub use linux::DesktopEnvt;
 
 #[cfg(target_os = "macos")]
-pub fn get_wallpaper() -> Result<String, Box<dyn Error>> {
-    // Generate the Applescript string
-    let cmd = r#"tell app "finder" to get posix path of (get desktop picture as alias)"#;
-    // Run it using osascript
-    let output = Command::new("osascript").args(&["-e", cmd]).output()?;
-
-    Ok(String::from_utf8(output.stdout)?.trim().into())
-}
-/// args - None
-/// return <Result, Error>
-/// Purpose - get the current envt
-#[cfg(target_os = "linux")]
-pub fn get_envt() -> Result<String, Box<dyn Error>> {
-    let desktop = std::env::var("XDG_CURRENT_DESKTOP")?;
-    if !is_gnome_compliant(&desktop) {
-        return Ok(desktop);
-    }
-    Ok(String::from("GNOME"))
-}
-
-/// args - filepath
-/// return - Result<(), Error>
-/// purpose - set's the wallpaper to filepath
-#[cfg(target_os = "linux")]
-pub fn set_paper(path: &str) -> Result<(), Box<dyn Error>> {
-    let path = enquote::enquote('"', &format!("{}", path));
-    // Getting desktop here
-    let desktop = get_envt()?;
-
-    match desktop.as_str() {
-        "GNOME" => {
-            Command::new("gsettings")
-                .args(&["set", "org.gnome.desktop.background", "picture-uri", &path])
-                .output()?;
-        }
-
-        "X-Cinnamon" => {
-            Command::new("dconf")
-                .args(&[
-                    "write",
-                    "/org/cinnamon/desktop/background/picture-uri",
-                    &path,
-                ])
-                .output()?;
-        }
-
-        "MATE" => {
-            let mate_path = &path[7..];
-            Command::new("dconf")
-                .args(&[
-                    "write",
-                    "/org/mate/desktop/background/picture-filename",
-                    &mate_path,
-                ])
-                .output()?;
-        }
-
-        "XFCE" => {
-            let xfce_path = &path[7..];
-            Command::new("xfconf-query")
-                .args(&[
-                    "-c",
-                    "xfce4-desktop",
-                    "-p",
-                    "/backdrop/screen0/monitor0/workspace0/last-image",
-                    "-s",
-                    &xfce_path,
-                ])
-                .output()?;
-        }
-
-        "Deepin" => {
-            Command::new("dconf")
-                .args(&[
-                    "write",
-                    "/com/deepin/wrap/gnome/desktop/background/picture-uri",
-                    &path,
-                ])
-                .output()?;
-        }
-
-        "KDE" => {
-            // KDE needs plasma shell scripting
-            // to change the wallpaper
-            let kde_set_arg = format!(
-                r#"
-            const monitors = desktops()
-            for (var i = 0; i < monitors.length; i++) {{
-                monitors[i].wallpaperPlugin = "org.kde.image"
-                monitors[i].currentConfigGroup = ["Wallpaper"]
-                monitors[i].writeConfig("Image", {})
-            }}"#,
-                &path
-            );
-
-            Command::new("qdbus")
-                .args(&[
-                    "org.kde.plasmashell",
-                    "/PlasmaShell",
-                    "org.kde.PlasmaShell.evaluateScript",
-                    &kde_set_arg,
-                ])
-                .output()?;
-        }
-        // Panics since flowy does not support others yet
-        _ => panic!("Unsupported Desktop Environment"),
-    }
-
-    Ok(())
-}
-
+mod macos;
 #[cfg(target_os = "macos")]
-pub fn set_paper(path: &str) -> Result<(), Box<dyn Error>> {
-    // Generate the Applescript string
-    let cmd = &format!(
-        r#"tell app "finder" to set desktop picture to POSIX file {}"#,
-        enquote::enquote('"', path),
-    );
-    // Run it using osascript
-    Command::new("osascript").args(&["-e", cmd]).output()?;
+pub use macos::DesktopEnvt;
 
-    Ok(())
+/// A trait implemented by desktop environments. It allows setting or getting a wallpaper.
+pub trait Desktop: Sized {
+    fn new() -> Result<Self, Box<dyn Error>>;
+
+    fn set_wallpaper(&self, path: &str) -> Result<(), Box<dyn Error>>;
+
+    fn get_wallpaper(&self) -> Result<PathBuf, Box<dyn Error>>;
 }

--- a/src/wallpapers.rs
+++ b/src/wallpapers.rs
@@ -14,10 +14,26 @@ mod macos;
 pub use macos::DesktopEnvt;
 
 /// A trait implemented by desktop environments. It allows setting or getting a wallpaper.
+///
+/// On platforms where only one desktop environment exists (e.g. Windows, macOS), this can
+/// be implemented with a zero-sized type. On Linux, it is an enum.
 pub trait Desktop: Sized {
+    /// Creates a new instance of this desktop.
+    ///
+    /// On Linux, this function detects the desktop environment.
+    /// It panics if the desktop environment is unsupported. It returns an error
+    /// if the desktop environment couldn't be determined (i.e., the `XDG_CURRENT_DESKTOP`
+    /// environment variable isn't set).
     fn new() -> Result<Self, Box<dyn Error>>;
 
+    /// Sets the wallpaper for all computer screens to the specified file path.
+    ///
+    /// The file should be an image file supported by the patform, e.g. a JPEG.
     fn set_wallpaper(&self, path: &str) -> Result<(), Box<dyn Error>>;
 
+    /// Returns the file path to the image used as the wallpaper.
+    ///
+    /// If different screens have different wallpapers, only one of them is returned;
+    /// the behavior depends on the platform and desktop environment.
     fn get_wallpaper(&self) -> Result<PathBuf, Box<dyn Error>>;
 }

--- a/src/wallpapers/linux.rs
+++ b/src/wallpapers/linux.rs
@@ -1,0 +1,177 @@
+use super::Desktop;
+use std::error::Error;
+use std::io::BufRead;
+use std::path::PathBuf;
+use std::process::Command;
+
+/// A desktop environment
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum DesktopEnvt {
+    Gnome,
+    Cinnamon,
+    Mate,
+    Xfce,
+    Deepin,
+    Kde,
+}
+
+impl Desktop for DesktopEnvt {
+    fn new() -> Result<Self, Box<dyn Error>> {
+        let desktop = std::env::var("XDG_CURRENT_DESKTOP")?;
+        if is_gnome_compliant(&desktop) {
+            Ok(DesktopEnvt::Gnome)
+        } else {
+            Ok(match &desktop[..] {
+                "X-Cinnamon" => DesktopEnvt::Cinnamon,
+                "MATE" => DesktopEnvt::Mate,
+                "XFCE" => DesktopEnvt::Xfce,
+                "Deepin" => DesktopEnvt::Deepin,
+                "KDE" => DesktopEnvt::Kde,
+                _ => panic!("Unsupported Desktop Environment"),
+            })
+        }
+    }
+
+    fn set_wallpaper(&self, path: &str) -> Result<(), Box<dyn Error>> {
+        let path = enquote::enquote('"', &format!("{}", path));
+
+        match self {
+            DesktopEnvt::Gnome => {
+                Command::new("gsettings")
+                    .args(&["set", "org.gnome.desktop.background", "picture-uri", &path])
+                    .output()?;
+            }
+
+            DesktopEnvt::Cinnamon => {
+                Command::new("dconf")
+                    .args(&[
+                        "write",
+                        "/org/cinnamon/desktop/background/picture-uri",
+                        &path,
+                    ])
+                    .output()?;
+            }
+
+            DesktopEnvt::Mate => {
+                let mate_path = &path[7..];
+                Command::new("dconf")
+                    .args(&[
+                        "write",
+                        "/org/mate/desktop/background/picture-filename",
+                        &mate_path,
+                    ])
+                    .output()?;
+            }
+
+            DesktopEnvt::Xfce => {
+                let xfce_path = &path[7..];
+                Command::new("xfconf-query")
+                    .args(&[
+                        "-c",
+                        "xfce4-desktop",
+                        "-p",
+                        "/backdrop/screen0/monitor0/workspace0/last-image",
+                        "-s",
+                        &xfce_path,
+                    ])
+                    .output()?;
+            }
+
+            DesktopEnvt::Deepin => {
+                Command::new("dconf")
+                    .args(&[
+                        "write",
+                        "/com/deepin/wrap/gnome/desktop/background/picture-uri",
+                        &path,
+                    ])
+                    .output()?;
+            }
+
+            DesktopEnvt::Kde => {
+                // KDE needs plasma shell scripting to change the wallpaper
+                let kde_set_arg = format!(
+                    r#"
+                    const monitors = desktops()
+                    for (var i = 0; i < monitors.length; i++) {{
+                        monitors[i].currentConfigGroup = ["Wallpaper"]
+                        monitors[i].writeConfig("Image", {})
+                    }}"#,
+                    &path
+                );
+
+                Command::new("qdbus")
+                    .args(&[
+                        "org.kde.plasmashell",
+                        "/PlasmaShell",
+                        "org.kde.PlasmaShell.evaluateScript",
+                        &kde_set_arg,
+                    ])
+                    .output()?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn get_wallpaper(&self) -> Result<PathBuf, Box<dyn Error>> {
+        let output = match self {
+            DesktopEnvt::Gnome => Command::new("gsettings")
+                .args(&["get", "org.gnome.desktop.background", "picture-uri"])
+                .output()?,
+
+            DesktopEnvt::Cinnamon => Command::new("dconf")
+                .arg("read")
+                .arg("/org/cinnamon/desktop/background/picture-uri")
+                .output()?,
+
+            DesktopEnvt::Mate => Command::new("dconf")
+                .args(&["read", "/org/mate/desktop/background/picture-filename"])
+                .output()?,
+
+            DesktopEnvt::Xfce => Command::new("xfconf-query")
+                .args(&[
+                    "-c",
+                    "xfce4-desktop",
+                    "-p",
+                    "/backdrop/screen0/monitor0/workspace0/last-image",
+                ])
+                .output()?,
+
+            DesktopEnvt::Deepin => Command::new("dconf")
+                .args(&[
+                    "read",
+                    "/com/deepin/wrap/gnome/desktop/background/picture-uri",
+                ])
+                .output()?,
+
+            DesktopEnvt::Kde => return Ok(kde_get()?),
+        };
+
+        let output = enquote::unquote(String::from_utf8(output.stdout)?.trim().into())?;
+        Ok(PathBuf::from(output))
+    }
+}
+
+/// Check if desktop is Gnome compliant
+fn is_gnome_compliant(desktop: &str) -> bool {
+    desktop.contains("GNOME") || desktop == "Unity" || desktop == "Pantheon"
+}
+
+fn kde_get() -> Result<PathBuf, Box<dyn Error>> {
+    // Getting current directory and
+    // appending the kde wallpaper
+    // repo to the end of the path
+    let mut path = std::env::current_dir()?.display().to_string();
+    path.push_str("/plasma-org.kde.plasma.desktop-appletsrc");
+    // Opening the file into a buffer reader
+    let file = std::fs::File::open(path)?;
+    let reader = std::io::BufReader::new(file);
+    for line in reader.lines() {
+        let line = line?;
+        if line.starts_with("Image=") {
+            return Ok(line[6..].trim().into());
+        }
+    }
+
+    Err("KDE Image not found".into())
+}

--- a/src/wallpapers/linux.rs
+++ b/src/wallpapers/linux.rs
@@ -7,26 +7,26 @@ use std::process::Command;
 /// A desktop environment
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum DesktopEnvt {
-    Gnome,
+    GNOME,
     Cinnamon,
-    Mate,
-    Xfce,
+    MATE,
+    XFCE,
     Deepin,
-    Kde,
+    KDE,
 }
 
 impl Desktop for DesktopEnvt {
     fn new() -> Result<Self, Box<dyn Error>> {
         let desktop = std::env::var("XDG_CURRENT_DESKTOP")?;
         if is_gnome_compliant(&desktop) {
-            Ok(DesktopEnvt::Gnome)
+            Ok(DesktopEnvt::GNOME)
         } else {
             Ok(match &desktop[..] {
                 "X-Cinnamon" => DesktopEnvt::Cinnamon,
-                "MATE" => DesktopEnvt::Mate,
-                "XFCE" => DesktopEnvt::Xfce,
+                "MATE" => DesktopEnvt::MATE,
+                "XFCE" => DesktopEnvt::XFCE,
                 "Deepin" => DesktopEnvt::Deepin,
-                "KDE" => DesktopEnvt::Kde,
+                "KDE" => DesktopEnvt::KDE,
                 _ => panic!("Unsupported Desktop Environment"),
             })
         }
@@ -36,7 +36,7 @@ impl Desktop for DesktopEnvt {
         let path = enquote::enquote('"', &format!("{}", path));
 
         match self {
-            DesktopEnvt::Gnome => {
+            DesktopEnvt::GNOME => {
                 Command::new("gsettings")
                     .args(&["set", "org.gnome.desktop.background", "picture-uri", &path])
                     .output()?;
@@ -52,7 +52,7 @@ impl Desktop for DesktopEnvt {
                     .output()?;
             }
 
-            DesktopEnvt::Mate => {
+            DesktopEnvt::MATE => {
                 let mate_path = &path[7..];
                 Command::new("dconf")
                     .args(&[
@@ -63,7 +63,7 @@ impl Desktop for DesktopEnvt {
                     .output()?;
             }
 
-            DesktopEnvt::Xfce => {
+            DesktopEnvt::XFCE => {
                 let xfce_path = &path[7..];
                 Command::new("xfconf-query")
                     .args(&[
@@ -87,7 +87,7 @@ impl Desktop for DesktopEnvt {
                     .output()?;
             }
 
-            DesktopEnvt::Kde => {
+            DesktopEnvt::KDE => {
                 // KDE needs plasma shell scripting to change the wallpaper
                 let kde_set_arg = format!(
                     r#"
@@ -115,7 +115,7 @@ impl Desktop for DesktopEnvt {
 
     fn get_wallpaper(&self) -> Result<PathBuf, Box<dyn Error>> {
         let output = match self {
-            DesktopEnvt::Gnome => Command::new("gsettings")
+            DesktopEnvt::GNOME => Command::new("gsettings")
                 .args(&["get", "org.gnome.desktop.background", "picture-uri"])
                 .output()?,
 
@@ -124,11 +124,11 @@ impl Desktop for DesktopEnvt {
                 .arg("/org/cinnamon/desktop/background/picture-uri")
                 .output()?,
 
-            DesktopEnvt::Mate => Command::new("dconf")
+            DesktopEnvt::MATE => Command::new("dconf")
                 .args(&["read", "/org/mate/desktop/background/picture-filename"])
                 .output()?,
 
-            DesktopEnvt::Xfce => Command::new("xfconf-query")
+            DesktopEnvt::XFCE => Command::new("xfconf-query")
                 .args(&[
                     "-c",
                     "xfce4-desktop",
@@ -144,7 +144,7 @@ impl Desktop for DesktopEnvt {
                 ])
                 .output()?,
 
-            DesktopEnvt::Kde => return Ok(kde_get()?),
+            DesktopEnvt::KDE => return Ok(kde_get()?),
         };
 
         let output = enquote::unquote(String::from_utf8(output.stdout)?.trim().into())?;
@@ -159,7 +159,7 @@ fn is_gnome_compliant(desktop: &str) -> bool {
 
 fn kde_get() -> Result<PathBuf, Box<dyn Error>> {
     // Getting current directory and
-    // appending the kde wallpaper
+    // appending the KDE wallpaper
     // repo to the end of the path
     let mut path = std::env::current_dir()?.display().to_string();
     path.push_str("/plasma-org.kde.plasma.desktop-appletsrc");

--- a/src/wallpapers/macos.rs
+++ b/src/wallpapers/macos.rs
@@ -1,0 +1,34 @@
+use super::Desktop;
+use std::error::Error;
+use std::path::PathBuf;
+use std::process::Command;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct DesktopEnvt;
+
+impl Desktop for DesktopEnvt {
+    fn new() -> Result<Self, Box<dyn std::error::Error>> {
+        Ok(Self)
+    }
+
+    fn set_wallpaper(&self, path: &str) -> Result<(), Box<dyn Error>> {
+        // Generate the Applescript string
+        let cmd = &format!(
+            r#"tell app "finder" to set desktop picture to POSIX file {}"#,
+            enquote::enquote('"', path),
+        );
+        // Run it using osascript
+        Command::new("osascript").args(&["-e", cmd]).output()?;
+
+        Ok(())
+    }
+
+    fn get_wallpaper(&self) -> Result<PathBuf, Box<dyn Error>> {
+        // Generate the Applescript string
+        let cmd = r#"tell app "finder" to get posix path of (get desktop picture as alias)"#;
+        // Run it using osascript
+        let output = Command::new("osascript").args(&["-e", cmd]).output()?;
+
+        Ok(String::from_utf8(output.stdout)?.trim().into())
+    }
+}


### PR DESCRIPTION
This moves platform-dependent logic into separate submodules; there is a submodule for each platform.

This introduces an ```enum``` on Linux with all supported desktop environments and a Zero Sized ```struct``` on macOS. It introduces a ```sized Desktop``` trait to guarantee that all platforms have the same API.

I think that this change makes the code much clearer and simplifies future modifications.

I think this fixes #6.