### PR TITLE
Fix time calculation

### DIFF
--- a/flowy/src/lib.rs
+++ b/flowy/src/lib.rs
@@ -191,7 +191,7 @@ fn get_current_wallpaper_idx(wall_times: &[String]) -> Result<usize, Box<dyn Err
     // Get the current time
     let curr_time = Local::now().time();
 
-    // calculate index + 1
+    // Looping through times to compare all of them
     let mut index = 0;
     for time in wall_times {
         let time = NaiveTime::parse_from_str(&time, "%H:%M")?;
@@ -201,11 +201,8 @@ fn get_current_wallpaper_idx(wall_times: &[String]) -> Result<usize, Box<dyn Err
         index += 1;
     }
     if index == 0 {
-        // The first time should ALWAYS be "00:00". If not, this can happen:
-        panic!(
-            "Current time ({:?}) is earlier than first wallpaper time ({:?})",
-            curr_time, wall_times[0]
-        );
+        index = wall_times.len() - 1;
+        return Ok(index);
     }
     Ok(index - 1)
 }

--- a/flowy/src/lib.rs
+++ b/flowy/src/lib.rs
@@ -200,6 +200,9 @@ fn get_current_wallpaper_idx(wall_times: &[String]) -> Result<usize, Box<dyn Err
         }
         index += 1;
     }
+    
+    // In case the current time is lower that the first time, 
+    // we just loop back to the time before it
     if index == 0 {
         index = wall_times.len() - 1;
         return Ok(index);


### PR DESCRIPTION
Currently, `get_current_wallpaper_idx` returns the index whose time is closest to the current time. I believe this is wrong.

For example, if the times are "00:00", "01:00" and "02:00", the first image should be shown from 00:00 to 00:59 and the second image from 01:00 to 01:59.

However, at 00:59, `get_current_wallpaper_idx` would currently return the index for "01:00", since 00:59 is closer to 01:00 than to 00:00.

This PR changes the function to return the index of the _last_ time that isn't greater than the current time.