### PR TITLE
Fix get_wallpaper on KDE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cbcf9241d9e8d106295bd496bbe2e9cffd5fa098f2a8c9e2bbcbf09773c11a8"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys-next"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,6 +876,7 @@ checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 name = "wallpaper_rs"
 version = "0.1.0"
 dependencies = [
+ "dirs-next",
  "enquote",
 ]
 

--- a/wallpaper_rs/Cargo.toml
+++ b/wallpaper_rs/Cargo.toml
@@ -14,3 +14,9 @@ keywords = ["desktop", "wallpaper", "background"]
 
 [dependencies]
 enquote = "1.0.3"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+dirs-next = "1.0"
+
+[[example]]
+name = "get_wallpaper"

--- a/wallpaper_rs/examples/get_wallpaper.rs
+++ b/wallpaper_rs/examples/get_wallpaper.rs
@@ -1,0 +1,7 @@
+use wallpaper_rs::{Desktop, DesktopEnvt};
+
+fn main() {
+    let d = DesktopEnvt::new().expect("Desktop environment couldn't be determined");
+    // This prints Ok(<file path>) on success and Err(<error message>) on failure
+    println!("{:?}", d.get_wallpaper());
+}

--- a/wallpaper_rs/src/linux.rs
+++ b/wallpaper_rs/src/linux.rs
@@ -152,7 +152,7 @@ impl Desktop for DesktopEnvt {
                     "/com/deepin/wrap/gnome/desktop/background/picture-uri",
                 ])
                 .output()?,
-            DesktopEnvt::KDE => return Ok(kde_get()?),
+            DesktopEnvt::KDE => return Ok(kde_get_wallpaper()?),
             DesktopEnvt::BSPWM => Command::new("sed")
                 .args(&[
                     "-n",
@@ -172,12 +172,16 @@ fn is_gnome_compliant(desktop: &str) -> bool {
     desktop.contains("GNOME") || desktop == "Unity" || desktop == "Pantheon"
 }
 
-fn kde_get() -> Result<PathBuf, Box<dyn Error>> {
-    let mut config_dir = dirs_next::config_dir().ok_or("Could not determine config directory")?;
-    config_dir.push("plasma-org.kde.plasma.desktop-appletsrc");
+/// Returns the absolute wallpaper path on KDE, if possible.
+///
+/// It reads the first line starting with "Image="
+/// in the file "~/.config/plasma-org.kde.plasma.desktop-appletsrc"
+fn kde_get_wallpaper() -> Result<PathBuf, Box<dyn Error>> {
+    let mut path = dirs_next::config_dir().ok_or("Could not determine config directory")?;
+    path.push("plasma-org.kde.plasma.desktop-appletsrc");
 
     // Opening the file into a buffer reader
-    let file = std::fs::File::open(config_dir)?;
+    let file = std::fs::File::open(path)?;
 
     let reader = std::io::BufReader::new(file);
     for line in reader.lines() {


### PR DESCRIPTION
This fixes the `get_wallpaper` function on KDE. Whether this function works can now easily be tested with

```fish
$ cd wallpaper_rs
$ cargo run --example get_wallpaper
```