### PR TITLE
Set badge urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="https://raw.githubusercontent.com/vineetred/nGram/vineetred-patch-1/isolated-monochrome-black.svg" width="20%"> </img>
 
-[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0) ![crates.io](https://img.shields.io/crates/v/flowy.svg) ![CI](https://github.com/vineetred/flowy/workflows/CI/badge.svg?branch=master)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0) [![crates.io](https://img.shields.io/crates/v/flowy.svg)](https://crates.io/crates/flowy) [![CI](https://github.com/vineetred/flowy/workflows/CI/badge.svg?branch=master)](https://github.com/vineetred/flowy/actions)
 
 
 ## Demo


### PR DESCRIPTION
Whenever a badge was clicked, the badge's icon was opened in the window instead of the destination.
Now badges point to their content.