### PR TITLE
Automated CI/CD pipeline to generate binaries

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -52,6 +52,7 @@ jobs:
     needs: [build-linux-gnu, release-macos, release-windows]
     steps:
     - uses: actions/download-artifact@v2.0.8
+    - run: ls
     - uses: anton-yurchenko/git-release@v3.4.3
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -49,6 +49,8 @@ jobs:
     needs: [build-linux-gnu, release-macos, release-windows]
     steps:
     - uses: anton-yurchenko/git-release@v3.4.3
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         args: |
               flowy_linux_gnu.zip

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -38,7 +38,7 @@ jobs:
     - uses: actions/upload-artifact@v2.2.2
       with:
         name: flowy_windows
-        path: target/release/flowy
+        path: target/release/flowy.exe
     - uses: actions/download-artifact@v2.0.8
       with:
         name: flowy_windows

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -35,7 +35,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: cargo build --release
-    - name: Upload a Build Artifact
     - uses: actions/upload-artifact@v2.2.2
       with:
         name: flowy_windows

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -2,12 +2,10 @@ name: Publish binaries to Releases
 
 on:
   push:
-    branches: [ master ]
     tags:
       - '*'
     
   pull_request:
-    branches: [ master ]
     tags:
       - '*'
 

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -56,13 +56,13 @@ jobs:
     - run: zip flowy_linux_gnu.zip flowy_linux_gnu/flowy
     - run: zip flowy_macos.zip flowy_macos/flowy
     - run: zip flowy_windows.zip flowy_windows/flowy.exe
-    - uses: anton-yurchenko/git-release@v3.4.3
+    - uses: docker://antonyurchenko/git-release:latest
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DRAFT_RELEASE: "false"
           PRE_RELEASE: "false"
           CHANGELOG_FILE: "CHANGELOG.md"
-          ALLOW_EMPTY_CHANGELOG: "false"
+          ALLOW_EMPTY_CHANGELOG: "true"
       with:
         args: |
               flowy_linux_gnu.zip

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -58,6 +58,10 @@ jobs:
     - uses: anton-yurchenko/git-release@v3.4.3
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRAFT_RELEASE: "false"
+          PRE_RELEASE: "false"
+          CHANGELOG_FILE: "CHANGELOG.md"
+          ALLOW_EMPTY_CHANGELOG: "false"
       with:
         args: |
               flowy_linux_gnu.zip

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -4,36 +4,30 @@ on:
   push:
     branches: [ master ]
     tags:
-      - release-v*
+      - v*
     
   pull_request:
     branches: [ master ]
     tags:
-      - release-v*
+      - v*
 
 jobs:
   build-linux-gnu:
-    name: Build for linux/GNU 
+    name: Build for Linux/GNU 
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - run: rustup target add x86_64-unknown-linux-gnu
     - run: cargo build --release --target=x86_64-unknown-linux-gnu
-    - uses: actions/upload-artifact@v1
-      with:
-        name: flowy_linux_gnu
-        path: target/release-linux/flowy
-
+    - run: zip flowy_linux_gnu.zip target/x86_64-unknown-linux-gnu/release/flowy
+        
   release-macos:
     name: Build for macOS
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
     - run: cargo build --release
-    - uses: actions/upload-artifact@v1
-      with:
-        name: flowy_macos
-        path: target/release/flowy
+    - run: zip flowy_macos.zip target/release/flowy
 
   release-windows:
     name: Build for Windows
@@ -41,17 +35,16 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: cargo build --release
-    - uses: actions/upload-artifact@v1
-      with:
-        name: flowy_windows
-        path: target/release/flowy.exe
+    - run: zip flowy_windows.zip target/release/flowy.exe
         
-  push-to-releases:
-     runs-on: ubuntu-latest
-     steps:
-       - uses: GoogleCloudPlatform/release-please-action@v1.3.0
-         with:
-           token: ${{ secrets.GITHUB_TOKEN }}
-           path: target/release
-           release-type: rust
-           package-name: release-please-action
+  publish-release:
+    name: Publish release
+    runs-on: ubuntu-latest
+    needs: [build-linux-gnu, release-macos, release-windows]
+    steps:
+    - uses: anton-yurchenko/git-release@v3.4.3
+      with:
+        args: |
+              flowy_linux_gnu.zip
+              flowy_macos.zip
+              flowy_windows.zip

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -51,6 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-linux-gnu, release-macos, release-windows]
     steps:
+    - uses: actions/checkout@v2
     - uses: actions/download-artifact@v2.0.8
     - run: zip flowy_linux_gnu.zip flowy_linux_gnu/flowy
     - run: zip flowy_macos.zip flowy_macos/flowy

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,57 @@
+name: Publish binaries to Releases
+
+on:
+  push:
+    branches: [ master ]
+    tags:
+      - release-v*
+    
+  pull_request:
+    branches: [ master ]
+    tags:
+      - release-v*
+
+jobs:
+  build-linux-gnu:
+    name: Build for linux/GNU 
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: rustup target add x86_64-unknown-linux-gnu
+    - run: cargo build --release --target=x86_64-unknown-linux-gnu
+    - uses: actions/upload-artifact@v1
+      with:
+        name: flowy_linux_gnu
+        path: target/release-linux/flowy
+
+  release-macos:
+    name: Build for macOS
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: cargo build --release
+    - uses: actions/upload-artifact@v1
+      with:
+        name: flowy_macos
+        path: target/release/flowy
+
+  release-windows:
+    name: Build for Windows
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: cargo build --release
+    - uses: actions/upload-artifact@v1
+      with:
+        name: flowy_windows
+        path: target/release/flowy.exe
+        
+  push-to-releases:
+     runs-on: ubuntu-latest
+     steps:
+       - uses: GoogleCloudPlatform/release-please-action@v1.3.0
+         with:
+           token: ${{ secrets.GITHUB_TOKEN }}
+           path: target/release
+           release-type: rust
+           package-name: release-please-action

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -19,7 +19,10 @@ jobs:
     - uses: actions/checkout@v2
     - run: rustup target add x86_64-unknown-linux-gnu
     - run: cargo build --release --target=x86_64-unknown-linux-gnu
-    - run: zip flowy_linux_gnu.zip target/x86_64-unknown-linux-gnu/release/flowy
+    - uses: actions/upload-artifact@v1
+      with:
+        name: flowy_linux_gnu
+        path: target/x86_64-unknown-linux-gnu/release/flowy
         
   release-macos:
     name: Build for macOS
@@ -27,7 +30,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: cargo build --release
-    - run: zip flowy_macos.zip target/release/flowy
+    - uses: actions/upload-artifact@v1
+      with:
+        name: flowy_macos
+        path: target/release/flowy
 
   release-windows:
     name: Build for Windows
@@ -39,15 +45,13 @@ jobs:
       with:
         name: flowy_windows
         path: target/release/flowy.exe
-    - uses: actions/download-artifact@v2.0.8
-      with:
-        name: flowy_windows
         
   publish-release:
     name: Publish release
     runs-on: ubuntu-latest
     needs: [build-linux-gnu, release-macos, release-windows]
     steps:
+    - uses: actions/download-artifact@v2.0.8
     - uses: anton-yurchenko/git-release@v3.4.3
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -52,12 +52,11 @@ jobs:
     needs: [build-linux-gnu, release-macos, release-windows]
     steps:
     - uses: actions/download-artifact@v2.0.8
-    - run: ls
     - uses: anton-yurchenko/git-release@v3.4.3
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         args: |
-              flowy_linux_gnu.zip
-              flowy_macos.zip
-              flowy_windows.zip
+              flowy_linux_gnu/flowy_linux_gnu.zip
+              flowy_macos/flowy_macos.zip
+              flowy_windows/flowy_windows.zip

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -35,7 +35,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: cargo build --release
-    - run: zip flowy_windows.zip target/release/flowy.exe
+    - name: Upload a Build Artifact
+    - uses: actions/upload-artifact@v2.2.2
+      with:
+        name: flowy_windows
+        path: target/release/flowy
+    - uses: actions/download-artifact@v2.0.8
+      with:
+        name: flowy_windows
         
   publish-release:
     name: Publish release

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -52,11 +52,14 @@ jobs:
     needs: [build-linux-gnu, release-macos, release-windows]
     steps:
     - uses: actions/download-artifact@v2.0.8
+    - run: zip flowy_linux_gnu.zip flowy_linux_gnu/flowy
+    - run: zip flowy_macos.zip flowy_macos/flowy
+    - run: zip flowy_windows.zip flowy_windows/flowy.exe
     - uses: anton-yurchenko/git-release@v3.4.3
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         args: |
-              flowy_linux_gnu/flowy_linux_gnu.zip
-              flowy_macos/flowy_macos.zip
-              flowy_windows/flowy_windows.zip
+              flowy_linux_gnu.zip
+              flowy_macos.zip
+              flowy_windows.zip

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -4,12 +4,12 @@ on:
   push:
     branches: [ master ]
     tags:
-      - *
+      - '*'
     
   pull_request:
     branches: [ master ]
     tags:
-      - *
+      - '*'
 
 jobs:
   build-linux-gnu:

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -4,12 +4,12 @@ on:
   push:
     branches: [ master ]
     tags:
-      - v*
+      - *
     
   pull_request:
     branches: [ master ]
     tags:
-      - v*
+      - *
 
 jobs:
   build-linux-gnu:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+## [0.4.0] - 2021-02-16
+### Added
+- Support for the new Apple Silicon M1 Macs.
+
+### Fixed
+- Multiple bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.4.1] - 2021-02-16
+### Added
+- Automated build release on GitHub
+
 ## [0.4.0] - 2021-02-16
 ### Added
 - Support for the new Apple Silicon M1 Macs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## [0.4.1] - 2021-02-16
+## [0.4.2] - 2021-02-16
 ### Added
-- Automated build release on GitHub
+- Automated build release on GitHub.
 
 ## [0.4.0] - 2021-02-16
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-## [0.4.2] - 2021-02-16
-### Added
-- Automated build release on GitHub.
-
 ## [0.4.0] - 2021-02-16
 ### Added
 - Support for the new Apple Silicon M1 Macs.


### PR DESCRIPTION
GitHub Actions workflow that auto-generates a build (Linux/macOS/Windows) of Flowy and then pushes it to the Releases section. 

**Instructions:**
- For each new release, update `CHANGELOG.md`. **Strictly follow the [*Keep A Changelog*](https://keepachangelog.com/en/1.0.0/) style guide.**
- Once your branch is ready for a release, push a new tag. **Tag name should be same as the versioning entered in** `CHANGELOG.md`. Via git bash, `git push origin <tagname>`
- A new Release with binaries and source code will be ready! The release's text will be auto-populated from the new `CHANGELOG.md` entry.

_Request to maintainers:_ This was rapidly iterated with utter disregard for commit hygiene, so preferably squash and merge this PR to not muck up your commit history.

Resolves issue #37. 