### PR TITLE
Fix the time comparison algorithm

### DIFF
--- a/flowy/src/lib.rs
+++ b/flowy/src/lib.rs
@@ -201,20 +201,17 @@ fn get_current_wallpaper_idx(wall_times: &[String]) -> Result<usize, Box<dyn Err
     let curr_time = Local::now().time();
 
     // Looping through times to compare all of them
-    let mut index = 0;
-    for time in wall_times {
-        let time = NaiveTime::parse_from_str(&time, "%H:%M")?;
-        if time > curr_time {
-            break;
+    for i in 0..(wall_times.len() - 1) {
+        let time = NaiveTime::parse_from_str(&wall_times[i], "%H:%M")?;
+        let next_time = NaiveTime::parse_from_str(&wall_times[i + 1], "%H:%M")?;
+        let mut matches = 0;
+        if curr_time >= time { matches += 1; }
+        if curr_time < next_time { matches += 1; }
+        if time > next_time { matches += 1; }
+        if matches >= 2 {
+            return Ok(i);
         }
-        index += 1;
     }
 
-    // In case the current time is lower that the first time,
-    // we just loop back to the time before it
-    if index == 0 {
-        index = wall_times.len() - 1;
-        return Ok(index);
-    }
-    Ok(index - 1)
+    return Ok(wall_times.len() - 1);
 }


### PR DESCRIPTION
The current time comparison algorithm does not work if the time is not ordered from smallest to largest.
This happens when using the *solar* mode.

Note: The examples below use my pull request "Add more debugging/logging details" (https://github.com/vineetred/flowy/pull/62).

Bug reproduction; As you can see, `"05:18"` is selected instead of `"01:54"`:
```
$ faketime '2021-01-01T02:00:00' date
Fri 01 Jan 2021 02:00:00 AM CET

$ faketime '2021-01-01T02:00:00' ./flowy -s /path/to/lake-solar 0 0
<---- Solar Mode ---->
Lat: 0 Long: 0
Wallpapers:
- "07:00" = "file:///path/to/lake-solar/DAY-01.jpg"
- "08:31" = "file:///path/to/lake-solar/DAY-02.jpg"
- "10:02" = "file:///path/to/lake-solar/DAY-03.jpg"
- "11:32" = "file:///path/to/lake-solar/DAY-04.jpg"
- "13:03" = "file:///path/to/lake-solar/DAY-05.jpg"
- "14:34" = "file:///path/to/lake-solar/DAY-06.jpg"
- "16:05" = "file:///path/to/lake-solar/DAY-07.jpg"
- "17:36" = "file:///path/to/lake-solar/DAY-08.jpg"
- "19:07" = "file:///path/to/lake-solar/NIGHT-01.jpg"
- "20:49" = "file:///path/to/lake-solar/NIGHT-02.jpg"
- "22:31" = "file:///path/to/lake-solar/NIGHT-03.jpg"
- "00:13" = "file:///path/to/lake-solar/NIGHT-04.jpg"
- "01:54" = "file:///path/to/lake-solar/NIGHT-05.jpg"
- "03:36" = "file:///path/to/lake-solar/NIGHT-06.jpg"
- "05:18" = "file:///path/to/lake-solar/NIGHT-07.jpg"
<--- Daemon Listening --->
Set wallpaper: "05:18" = "file:///path/to/lake-solar/NIGHT-07.jpg"
```

--

To fix that, the new algorithm supports all cases for a circular list.

<details>
  <summary>Tests Result</summary>
  
  Command:
  ```bash
  for h in {00..23}; do
    date="2021-01-01T${h}:00:00"
    echo -n "[[ ${date} ]]  "
    faketime "$date" timeout .1 ./flowy -s /path/to/lake-solar 0 0 | grep -Fm1 'Set wallpaper'
  done
  ```

  Before:
  ```
  [[ 2021-01-01T00:00:00 ]]  Set wallpaper: "05:18" = "file:///path/to/lake-solar/NIGHT-07.jpg"
  [[ 2021-01-01T01:00:00 ]]  Set wallpaper: "05:18" = "file:///path/to/lake-solar/NIGHT-07.jpg"
  [[ 2021-01-01T02:00:00 ]]  Set wallpaper: "05:18" = "file:///path/to/lake-solar/NIGHT-07.jpg"
  [[ 2021-01-01T03:00:00 ]]  Set wallpaper: "05:18" = "file:///path/to/lake-solar/NIGHT-07.jpg"
  [[ 2021-01-01T04:00:00 ]]  Set wallpaper: "05:18" = "file:///path/to/lake-solar/NIGHT-07.jpg"
  [[ 2021-01-01T05:00:00 ]]  Set wallpaper: "05:18" = "file:///path/to/lake-solar/NIGHT-07.jpg"
  [[ 2021-01-01T06:00:00 ]]  Set wallpaper: "05:18" = "file:///path/to/lake-solar/NIGHT-07.jpg"
  [[ 2021-01-01T07:00:00 ]]  Set wallpaper: "07:00" = "file:///path/to/lake-solar/DAY-01.jpg"
  [[ 2021-01-01T08:00:00 ]]  Set wallpaper: "07:00" = "file:///path/to/lake-solar/DAY-01.jpg"
  [[ 2021-01-01T09:00:00 ]]  Set wallpaper: "08:31" = "file:///path/to/lake-solar/DAY-02.jpg"
  [[ 2021-01-01T10:00:00 ]]  Set wallpaper: "08:31" = "file:///path/to/lake-solar/DAY-02.jpg"
  [[ 2021-01-01T11:00:00 ]]  Set wallpaper: "10:02" = "file:///path/to/lake-solar/DAY-03.jpg"
  [[ 2021-01-01T12:00:00 ]]  Set wallpaper: "11:32" = "file:///path/to/lake-solar/DAY-04.jpg"
  [[ 2021-01-01T13:00:00 ]]  Set wallpaper: "11:32" = "file:///path/to/lake-solar/DAY-04.jpg"
  [[ 2021-01-01T14:00:00 ]]  Set wallpaper: "13:03" = "file:///path/to/lake-solar/DAY-05.jpg"
  [[ 2021-01-01T15:00:00 ]]  Set wallpaper: "14:34" = "file:///path/to/lake-solar/DAY-06.jpg"
  [[ 2021-01-01T16:00:00 ]]  Set wallpaper: "14:34" = "file:///path/to/lake-solar/DAY-06.jpg"
  [[ 2021-01-01T17:00:00 ]]  Set wallpaper: "16:05" = "file:///path/to/lake-solar/DAY-07.jpg"
  [[ 2021-01-01T18:00:00 ]]  Set wallpaper: "17:36" = "file:///path/to/lake-solar/DAY-08.jpg"
  [[ 2021-01-01T19:00:00 ]]  Set wallpaper: "17:36" = "file:///path/to/lake-solar/DAY-08.jpg"
  [[ 2021-01-01T20:00:00 ]]  Set wallpaper: "19:07" = "file:///path/to/lake-solar/NIGHT-01.jpg"
  [[ 2021-01-01T21:00:00 ]]  Set wallpaper: "20:49" = "file:///path/to/lake-solar/NIGHT-02.jpg"
  [[ 2021-01-01T22:00:00 ]]  Set wallpaper: "20:49" = "file:///path/to/lake-solar/NIGHT-02.jpg"
  [[ 2021-01-01T23:00:00 ]]  Set wallpaper: "05:18" = "file:///path/to/lake-solar/NIGHT-07.jpg"
  ```

  After (with the fix):
  ```
  [[ 2021-01-01T00:00:00 ]]  Set wallpaper: "22:30" = "file:///path/to/lake-solar/NIGHT-03.jpg"
  [[ 2021-01-01T01:00:00 ]]  Set wallpaper: "00:13" = "file:///path/to/lake-solar/NIGHT-04.jpg"
  [[ 2021-01-01T02:00:00 ]]  Set wallpaper: "01:54" = "file:///path/to/lake-solar/NIGHT-05.jpg"
  [[ 2021-01-01T03:00:00 ]]  Set wallpaper: "01:54" = "file:///path/to/lake-solar/NIGHT-05.jpg"
  [[ 2021-01-01T04:00:00 ]]  Set wallpaper: "03:36" = "file:///path/to/lake-solar/NIGHT-06.jpg"
  [[ 2021-01-01T05:00:00 ]]  Set wallpaper: "03:36" = "file:///path/to/lake-solar/NIGHT-06.jpg"
  [[ 2021-01-01T06:00:00 ]]  Set wallpaper: "05:18" = "file:///path/to/lake-solar/NIGHT-07.jpg"
  [[ 2021-01-01T07:00:00 ]]  Set wallpaper: "07:00" = "file:///path/to/lake-solar/DAY-01.jpg"
  [[ 2021-01-01T08:00:00 ]]  Set wallpaper: "07:00" = "file:///path/to/lake-solar/DAY-01.jpg"
  [[ 2021-01-01T09:00:00 ]]  Set wallpaper: "08:31" = "file:///path/to/lake-solar/DAY-02.jpg"
  [[ 2021-01-01T10:00:00 ]]  Set wallpaper: "08:31" = "file:///path/to/lake-solar/DAY-02.jpg"
  [[ 2021-01-01T11:00:00 ]]  Set wallpaper: "10:02" = "file:///path/to/lake-solar/DAY-03.jpg"
  [[ 2021-01-01T12:00:00 ]]  Set wallpaper: "11:32" = "file:///path/to/lake-solar/DAY-04.jpg"
  [[ 2021-01-01T13:00:00 ]]  Set wallpaper: "11:32" = "file:///path/to/lake-solar/DAY-04.jpg"
  [[ 2021-01-01T14:00:00 ]]  Set wallpaper: "13:03" = "file:///path/to/lake-solar/DAY-05.jpg"
  [[ 2021-01-01T15:00:00 ]]  Set wallpaper: "14:34" = "file:///path/to/lake-solar/DAY-06.jpg"
  [[ 2021-01-01T16:00:00 ]]  Set wallpaper: "14:34" = "file:///path/to/lake-solar/DAY-06.jpg"
  [[ 2021-01-01T17:00:00 ]]  Set wallpaper: "16:05" = "file:///path/to/lake-solar/DAY-07.jpg"
  [[ 2021-01-01T18:00:00 ]]  Set wallpaper: "17:36" = "file:///path/to/lake-solar/DAY-08.jpg"
  [[ 2021-01-01T19:00:00 ]]  Set wallpaper: "17:36" = "file:///path/to/lake-solar/DAY-08.jpg"
  [[ 2021-01-01T20:00:00 ]]  Set wallpaper: "19:07" = "file:///path/to/lake-solar/NIGHT-01.jpg"
  [[ 2021-01-01T21:00:00 ]]  Set wallpaper: "20:49" = "file:///path/to/lake-solar/NIGHT-02.jpg"
  [[ 2021-01-01T22:00:00 ]]  Set wallpaper: "20:49" = "file:///path/to/lake-solar/NIGHT-02.jpg"
  [[ 2021-01-01T23:00:00 ]]  Set wallpaper: "22:31" = "file:///path/to/lake-solar/NIGHT-03.jpg"
  ```
</details>
