### PR TITLE
Updated dependencies and KDE command.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
 name = "enquote"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,9 +228,9 @@ checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
 name = "heck"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -282,9 +288,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.86"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "linked-hash-map"
@@ -596,15 +602,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.7.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"
@@ -656,9 +662,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wallpaper_rs"
@@ -666,6 +672,7 @@ version = "0.1.1"
 dependencies = [
  "dirs-next",
  "enquote",
+ "which",
  "winapi",
 ]
 
@@ -756,6 +763,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82015b7e0b8bad8185994674a13a93306bea76cf5a16c5a181382fd3a5ec2376"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "which"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
 ]
 
 [[package]]

--- a/flowy/Cargo.toml
+++ b/flowy/Cargo.toml
@@ -17,7 +17,7 @@ wallpaper_rs = { version = "0.1.1", path = "../wallpaper_rs" }
 enquote = "1.0.3"
 toml = "0.5"
 serde = { version = "1.0.114", features = ["derive"] }
-clap = { version = "3.0.0-beta.1", features = ["yaml"] }
+clap = { version = "=3.0.0-beta.2", features = ["yaml"] }
 flate2 = "1.0.16"
 tar = "0.4.36"
 directories-next = "2.0.0"

--- a/wallpaper_rs/Cargo.toml
+++ b/wallpaper_rs/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["desktop", "wallpaper", "background"]
 
 [dependencies]
 enquote = "1.0.3"
+which = "4.3.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.9", features = ["winuser"] }

--- a/wallpaper_rs/src/linux.rs
+++ b/wallpaper_rs/src/linux.rs
@@ -1,6 +1,7 @@
 use super::Desktop;
 use std::error::Error;
 use std::io::BufRead;
+use which::which;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -138,7 +139,19 @@ impl Desktop for DesktopEnvt {
                     &path
                 );
 
-                Command::new("qdbus")
+                let which_qdbus = which("qdbus");
+                
+                if which_qdbus.is_ok() {
+                    Command::new("qdbus")
+                        .args(&[
+                            "org.kde.plasmashell",
+                            "/PlasmaShell",
+                            "org.kde.PlasmaShell.evaluateScript",
+                            &kde_set_arg,
+                        ])
+                        .output()?;
+                } else {
+                    Command::new("qdbus-qt5")
                     .args(&[
                         "org.kde.plasmashell",
                         "/PlasmaShell",
@@ -146,6 +159,7 @@ impl Desktop for DesktopEnvt {
                         &kde_set_arg,
                     ])
                     .output()?;
+                }
             }
 
             DesktopEnvt::BSPWM | DesktopEnvt::I3 => {


### PR DESCRIPTION
Removed clap 3.0.0-beta.1 as it's not listed on docs.rs anymore. Forced flowy to use version 3.0.0-beta.2 which should fix issue #70 and possibly #66 & #65.

Some Linux distros running KDE don't have `qdbus` in `$PATH` but do have `qdbus-qt5`. Flowy will check for `qdbus` first and use `qdbus-qt5` if `qdbus` isn't in `$PATH`.